### PR TITLE
`lastmod` aware scraping

### DIFF
--- a/.github/workflows/publish-main.yml
+++ b/.github/workflows/publish-main.yml
@@ -1,4 +1,4 @@
-name: Publish Docker image
+name: Publish main Docker image
 on:
   push:
     tags:

--- a/.github/workflows/publish-review.yml
+++ b/.github/workflows/publish-review.yml
@@ -1,0 +1,23 @@
+name: Publish Docker image for review
+on:
+  push:
+    branches:
+      - '**'
+      - '!master'
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Copy repo files
+        uses: actions/checkout@v2
+
+      - name: Set env
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
+
+      - name: Publish image to GitHub Container Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+          docker pull ghcr.io/${{github.repository}}
+          docker build -t ghcr.io/${{github.repository}}:${{ env.RELEASE_VERSION }} . --cache-from ghcr.io/${{github.repository}}
+          docker push ghcr.io/${{github.repository}}:${{ env.RELEASE_VERSION }}

--- a/shopify_app_store/pipelines.py
+++ b/shopify_app_store/pipelines.py
@@ -113,5 +113,8 @@ class WriteToCSV(object):
             csv_out.writerow(row)
 
     def is_empty(self, file_name):
-        file = '{}{}'.format(self.OUTPUT_DIR, file_name)
-        return os.stat(file).st_size == 0
+        try:
+            file = '{}{}'.format(self.OUTPUT_DIR, file_name)
+            return os.stat(file).st_size == 0
+        except FileNotFoundError:
+            return True

--- a/shopify_app_store/pipelines.py
+++ b/shopify_app_store/pipelines.py
@@ -6,6 +6,7 @@
 # See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 
 import csv
+import os
 from .items import App, KeyBenefit, PricingPlan, PricingPlanFeature, Category, AppCategory, AppReview
 
 
@@ -46,17 +47,31 @@ class WriteToCSV(object):
         return item
 
     def write_file_headers(self):
-        self.write_header('apps.csv',
-                          ['id', 'url', 'title', 'developer', 'developer_link', 'icon', 'rating', 'reviews_count',
-                           'description_raw', 'description', 'tagline', 'pricing_hint', 'lastmod'])
-        self.write_header('reviews.csv',
-                          ['app_id', 'author', 'rating', 'posted_at', 'body', 'helpful_count', 'developer_reply',
-                           'developer_reply_posted_at'])
-        self.write_header('apps_categories.csv', ['app_id', 'category_id'])
-        self.write_header('categories.csv', ['id', 'title'])
-        self.write_header('pricing_plans.csv', ['id', 'app_id', 'title', 'price'])
-        self.write_header('pricing_plan_features.csv', ['app_id', 'pricing_plan_id', 'feature'])
-        self.write_header('key_benefits.csv', ['app_id', 'title', 'description'])
+        if self.is_empty('apps.csv'):
+            self.write_header('apps.csv',
+                              ['id', 'url', 'title', 'developer', 'developer_link', 'icon', 'rating', 'reviews_count',
+                               'description_raw', 'description', 'tagline', 'pricing_hint', 'lastmod'])
+
+        if self.is_empty('reviews.csv'):
+            self.write_header('reviews.csv',
+                              ['app_id', 'author', 'rating', 'posted_at', 'body', 'helpful_count', 'developer_reply',
+                               'developer_reply_posted_at'])
+
+        if self.is_empty('apps_categories.csv'):
+            self.write_header('apps_categories.csv', ['app_id', 'category_id'])
+
+        if self.is_empty('categories.csv'):
+            self.write_header('categories.csv', ['id', 'title'])
+
+        if self.is_empty('pricing_plans.csv'):
+            self.write_header('pricing_plans.csv', ['id', 'app_id', 'title', 'price'])
+
+        if self.is_empty('pricing_plan_features.csv'):
+            self.write_header('pricing_plan_features.csv', ['app_id', 'pricing_plan_id', 'feature'])
+
+        if self.is_empty('key_benefits.csv'):
+            self.write_header('key_benefits.csv', ['app_id', 'title', 'description'])
+
         return
 
     def store_app(self, app):
@@ -96,3 +111,7 @@ class WriteToCSV(object):
         with open('{}{}'.format(self.OUTPUT_DIR, file_name), 'a', encoding='utf-8') as out:
             csv_out = csv.writer(out)
             csv_out.writerow(row)
+
+    def is_empty(self, file_name):
+        file = '{}{}'.format(self.OUTPUT_DIR, file_name)
+        return os.stat(file).st_size == 0

--- a/shopify_app_store/settings.py
+++ b/shopify_app_store/settings.py
@@ -90,7 +90,7 @@ AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 
 # Retry middleware settings
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#module-scrapy.downloadermiddlewares.retry
-RETRY_TIMES = 10  # Maximum number of times to retry, in addition to the first download. (Default: 2)
+RETRY_TIMES = 100  # Maximum number of times to retry, in addition to the first download. (Default: 2)
 
 # Enable and configure HTTP caching (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings

--- a/shopify_app_store/settings.py
+++ b/shopify_app_store/settings.py
@@ -77,14 +77,14 @@ SPIDER_CONTRACTS = {
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
-#AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_ENABLED = True
 # The initial download delay
-#AUTOTHROTTLE_START_DELAY = 5
+AUTOTHROTTLE_START_DELAY = 30
 # The maximum download delay to be set in case of high latencies
-#AUTOTHROTTLE_MAX_DELAY = 60
+AUTOTHROTTLE_MAX_DELAY = 120
 # The average number of requests Scrapy should be sending in parallel to
 # each remote server
-#AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
+AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 # Enable showing throttling stats for every response received:
 #AUTOTHROTTLE_DEBUG = False
 

--- a/shopify_app_store/settings.py
+++ b/shopify_app_store/settings.py
@@ -88,6 +88,10 @@ AUTOTHROTTLE_TARGET_CONCURRENCY = 1.0
 # Enable showing throttling stats for every response received:
 #AUTOTHROTTLE_DEBUG = False
 
+# Retry middleware settings
+# See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#module-scrapy.downloadermiddlewares.retry
+RETRY_TIMES = 10  # Maximum number of times to retry, in addition to the first download. (Default: 2)
+
 # Enable and configure HTTP caching (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html#httpcache-middleware-settings
 #HTTPCACHE_ENABLED = True

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -162,8 +162,7 @@ class AppStoreSpider(LastmodSpider):
             rating = review.css(
                 '.review-metadata>div:nth-child(1) .ui-star-rating::attr(data-rating)').extract_first(
                 default='').strip()
-            posted_at = review.css(
-                '.review-metadata>div:nth-child(2) .review-metadata__item-value ::text').extract_first(
+            posted_at = review.css('.review-metadata .review-metadata__item-label ::text').extract_first(
                 default='').strip()
             body = BeautifulSoup(review.css('.review-content div').extract_first(), features='lxml').get_text().strip()
             helpful_count = review.css('.review-helpfulness .review-helpfulness__helpful-count ::text').extract_first()

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -56,14 +56,19 @@ class AppStoreSpider(LastmodSpider):
     @staticmethod
     def close(spider, reason):
         spider.logger.info('Spider closed: %s', spider.name)
-        spider.logger.info('Preparing unique categories...')
 
-        # @TODO Make this part also safe for 'incremental' parsing
         # Normalize categories
+        spider.logger.info('Preparing unique categories...')
         categories_df = pd.read_csv('output/categories.csv')
         categories_df.drop_duplicates(subset=['id', 'title']).to_csv('output/categories.csv', index=False)
-
         spider.logger.info('Unique categories are there 👌')
+
+        # Normalize apps
+        spider.logger.info('Preparing unique apps...')
+        apps_df = pd.read_csv('output/apps.csv')
+        apps_df.drop_duplicates(subset=['id'], keep='last').to_csv('output/apps.csv', index=False)
+        spider.logger.info('Unique apps are there 💎')
+
         return super().close(spider, reason)
 
     def parse_app(self, response):

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -80,6 +80,13 @@ class AppStoreSpider(LastmodSpider):
         apps_df.drop_duplicates(subset=['id'], keep='last').to_csv('output/apps.csv', index=False)
         spider.logger.info('Unique apps are there 💎')
 
+        # Normalize reviews
+        spider.logger.info('Preparing unique reviews...')
+        apps_df = pd.read_csv('output/reviews.csv')
+        apps_df.drop_duplicates(subset=['app_id', 'author', 'posted_at'], keep='last').to_csv('output/reviews.csv',
+                                                                                              index=False)
+        spider.logger.info('Unique reviews are there 🔥')
+
         return super().close(spider, reason)
 
     def parse_app(self, response):

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -181,8 +181,7 @@ class AppStoreSpider(LastmodSpider):
                     (self.processed_reviews['posted_at'] == posted_at) &
                     (self.processed_reviews['body'] == body)
                     ]
-                import pdb;
-                pdb.set_trace()
+
                 if not existing_review.empty:
                     self.logger.info("The last review of app was already scrapped, skipping the rest | App id : %s",
                                      app_id)

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -49,7 +49,7 @@ class AppStoreSpider(LastmodSpider):
                 self.logger.info('Skipping app as it hasn\'t changed since %s | URL: %s', persisted_app.get('lastmod'),
                                  app_url)
                 # Skip apps which were scraped and haven't changed since they were added to the list
-                yield None
+                return None
             else:
                 self.logger.info('App\'s page got updated since %s, taking the existing id %s | URL: %s',
                                  persisted_app.get('lastmod'), persisted_app.get('id'), app_url)

--- a/shopify_app_store/spiders/app_store.py
+++ b/shopify_app_store/spiders/app_store.py
@@ -40,17 +40,17 @@ class AppStoreSpider(LastmodSpider):
         app_url = re.compile(self.REVIEWS_REGEX).search(response.url).group(1)
         persisted_app = self.processed_apps.get(app_url, None)
 
-        # Skip apps which were scraped and haven't changed since they were added to the list
-        if (persisted_app is not None) and (persisted_app.get('lastmod') == response.meta['lastmod']):
-            self.logger.info('Skipping app as it hasn\'t changed since %s | URL: %s', persisted_app.get('lastmod'),
-                             app_url)
-            yield None
-
-        # Take id of the existing app
-        if (persisted_app is not None) and (persisted_app.get('lastmod') != response.meta['lastmod']):
-            self.logger.info('App\'s page got updated since %s, taking the existing id %s | URL: %s',
-                             persisted_app.get('lastmod'), persisted_app.get('id'), app_url)
-            app_id = persisted_app.get('id', app_id)
+        if persisted_app is not None:
+            if persisted_app.get('lastmod') == response.meta['lastmod']:
+                self.logger.info('Skipping app as it hasn\'t changed since %s | URL: %s', persisted_app.get('lastmod'),
+                                 app_url)
+                # Skip apps which were scraped and haven't changed since they were added to the list
+                yield None
+            else:
+                self.logger.info('App\'s page got updated since %s, taking the existing id %s | URL: %s',
+                                 persisted_app.get('lastmod'), persisted_app.get('id'), app_url)
+                # Take id of the existing app
+                app_id = persisted_app.get('id', app_id)
 
         response.meta['app_id'] = app_id
         self.processed_apps[app_url] = {


### PR DESCRIPTION
MR implements a few strategies that **decrease the number of requests issued by spider** and **allow spider to be run in resumable/incremental mode** (where after an interruption it doesn't rescrape items which were already collected). 

- [x] Skip apps that haven't changed since the last run (based on `lastmod`)
- [x] Update apps that were already added to CSV **and** changed since the last run
- [x] Reviews are getting incrementally scraped (and existing `app_id` re-used)
- [x] Duplicated categories are merged and re-assigned (or existing categories are used, without dups getting created)